### PR TITLE
orthographic corrections in batch04.txt

### DIFF
--- a/server/data/de/batch04.txt
+++ b/server/data/de/batch04.txt
@@ -15,7 +15,7 @@ Den osmanischen Bräuchen wohnt ein Zauber inne.
 Gegen den Sturm sind sie gewappnet, aber nicht gegen die Flut.
 Wer hat die Grillanzünder?
 Sie findet es anstrengend, Text auf dem Bildschirm zu lesen.
-Kurzentschlossen änderte er seine Route nach Finkenwerder.
+Kurz entschlossen änderte er seine Route nach Finkenwerder.
 Deshalb wurde er in den Zeugenstand gerufen.
 Bei viel Regen dehnt sich das Rückhaltebecken enorm aus.
 Nicht in jedem Kajak sitzt man alleine.
@@ -61,7 +61,7 @@ Manche Tierversuche machen sogar den Versuchstieren Spaß.
 Gehört das zur allgemein akzeptierten Praxis?
 Er macht seinem Ärger nicht Luft, sondern schluckt alles runter.
 Bis er eines Tages implodiert.
-Man kann nicht alles in sich hinein fressen.
+Man kann nicht alles in sich hineinfressen.
 Der bequeme Autofahrer gab einfach so viel Gas, dass die Beifahrertür von alleine zufiel.
 Wer war träger?
 Die Tür oder der Fahrer?
@@ -127,7 +127,7 @@ Für Fleischfresser ist das Futter nicht so bekömmlich.
 Der Auftritt erinnerte eher an den Musikantenstadl.
 Ein Marder hat wohl an den Bremsschläuchen geknabbert.
 Der Albtraum eines jeden Autofahrers!
-Meistens werden eher einige Kabel durchgebissen, so dass die Elektrik spinnt.
+Meistens werden eher einige Kabel durchgebissen, sodass die Elektrik spinnt.
 Sicherheitskritische Bauteile müssen stabil sein.
 Wie oft kam das bis jetzt vor?
 Vor ihnen liegt eine Durststrecke.
@@ -167,7 +167,7 @@ Genüsslich räkelt sie sich in der Sonne.
 Momentan grassiert die Schweinepest.
 Deshalb würde ich einfach diese Schutzkappe überstülpen und gut ist.
 War ja klar, dass einer es verhunzen wird.
-Lila ist das kurzwelligste noch sichtbare Licht.
+Violett ist das kurzwelligste noch sichtbare Licht.
 Plötzlich verkündeten alle Mitbewerber unisono, dass dies natürlich kein Problem darstelle.
 Die Nummer der Telefonseelsorge ist kostenlos und taucht nicht auf der Telefonrechnung auf.
 Es ziehen dunkle Wolken auf.
@@ -182,7 +182,7 @@ Schließe nicht von dir auf die Allgemeinheit.
 In einer Tageszeitung blätternd sitzt Siegfried auf einer Parkbank.
 Doch nun schlägt der stellvertretende Bürgermeister plötzlich ganz andere Töne an.
 Brautkleider werden total überbewertet.
-Er selbst ist der einzige, der sich witzig findet.
+Er selbst ist der Einzige, der sich witzig findet.
 Der Witz ist so schlecht, dass er schon wieder gut ist.
 Ja, aber das Wachstum ist komplett auf Pump finanziert.
 Brauchen wir einen Putzplan, oder klappt das auch so?


### PR DESCRIPTION
- kurz entschlossen: https://www.duden.de/rechtschreibung/kurz_entschlossen
- hineinfressen: https://www.duden.de/rechtschreibung/hineinfressen
- sodass: https://www.duden.de/rechtschreibung/sodass
- _inhaltlich:_ Violett: https://de.wikipedia.org/wiki/Violett
- der Einzige: [§ 57 (1)](https://grammis.ids-mannheim.de/rechtschreibung/6194) siehe Beispiel „Anita war die Einzige, die alles wusste.“ Zählt außerdem nicht zu den Ausnahmen in [§ 58 (5)](https://grammis.ids-mannheim.de/rechtschreibung/6194#par58)

Weitere Knackpunkte:
- Kann man überhaupt immer häufiger frequentieren? Das _häufig_ steckt in _frequentieren_ ja schon drin. Entweder man frequentiert oder man frequentiert nicht.
- Nach _erstmal_ und _nochmal_ kommt jetzt _schon mal_. Bei jedem der drei Wörter ist sowohl Getrennt- als auch Zusammenschreibung erlaubt, aber der Duden spricht immer eine Empfehlung zur Getrenntschreibung aus. Eine [Korpussuche des DWDS](https://dwds.de/r) zeigt auch, dass Getrenntschreibung deutlich gebräuchlicher ist. Die aktuelle Situation mit den _mal_-Wörtern ist irgendwie unschön, weil es jetzt auch nicht ganz konsistent ist.
- Optionales Komma bei „Drei Stufen auf einmal nehmend(,) hetzte sie die Treppe hinauf.“, genau so wie bei Satz 111 und Satz 182. Behalte das im Hinterkopf.